### PR TITLE
Add method to create one API Gateway per store

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,15 @@
   },
   "scripts": {
     "watch": "tsc -w",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "jest"
   },
   "bin": {
     "sfj-functions": "./index.js"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.20",
+    "jest": "^26.6.3",
+    "ts-jest": "^26.5.3"
   }
 }

--- a/provider/AWSProvider.test.ts
+++ b/provider/AWSProvider.test.ts
@@ -1,0 +1,6 @@
+import { AWSProvider } from './AWSProvider'
+
+test('bucket', async () => {
+  const provider = new AWSProvider('storecomponents')
+  console.log(await provider.apiGatewayId)
+})

--- a/provider/AWSProvider.ts
+++ b/provider/AWSProvider.ts
@@ -85,8 +85,8 @@ class AWSProvider extends BaseProvider {
    * @param {Buffer} file
    */
   private functionHash(file: Buffer) {
-    const shaObj = new jsSHA('SHA-224', 'ARRAYBUFFER');
-    shaObj.update(file)
+    const shaObj = new jsSHA('SHA-224', 'BYTES');
+    shaObj.update(file.toString())
     return shaObj.getHash('HEX')
   }
 
@@ -193,11 +193,13 @@ class AWSProvider extends BaseProvider {
 
     if (hash in existingFunctions) {
       console.log(`Updating function ${functionName}`)
+      console.log('Function hash', hash)
       await this.updateFunction(hash, content)
       console.log(`Function ${functionName} updated`)
     } else {
       console.log(`Creating function ${functionName}... `)
       const url = await this.createFunction(functionName, hash, content)
+      console.log('Function hash', hash)
       console.log(`Function ${functionName} created`)
       return url
     }

--- a/provider/AWSProvider.ts
+++ b/provider/AWSProvider.ts
@@ -1,13 +1,19 @@
 import { BaseProvider } from './BaseProvider'
-import AWS from 'aws-sdk'
+import AWS, { AWSError } from 'aws-sdk'
 import jsSHA from 'jssha'
 
+/** Implements the AWS provider for serverless functions */
 class AWSProvider extends BaseProvider {
   private _accountId: Promise<string>
+  private _apiGatewayId: Promise<string>
   private region: string
   private storeAccount: string
   private awsResource: string
 
+  /**
+   * Create an AWS provider
+   * @param {string} storeAccount The store's account
+   */
   public constructor(storeAccount: string) {
     super(storeAccount)
     this.storeAccount = storeAccount
@@ -17,6 +23,10 @@ class AWSProvider extends BaseProvider {
     AWS.config.update({ region: this.region })
   }
 
+  /**
+   * Retrieves the AWS Account ID based on caller's identity
+   * @returns {Promise<string>} The account id
+   */
   get accountId(): Promise<string> {
     if (this._accountId === undefined)
       this._accountId = ((new AWS.STS()).getCallerIdentity().promise()).then(x => x.Account)
@@ -24,12 +34,63 @@ class AWSProvider extends BaseProvider {
     return this._accountId
   }
 
+  /** Creates an API Gateway V2 for the store */
+  private async createApiGateway() {
+    const apiGateway = new AWS.ApiGatewayV2()
+
+    const gateway = await apiGateway.createApi({
+      Name: `sfj-${this.storeAccount}`,
+      ProtocolType: "HTTP",
+    }).promise()
+
+    return gateway.ApiId
+  }
+
+  /**
+   * Retrieves from S3 the API Gateway ID for the store, creating it if needed.
+   * @returns {Promise<string>} The API Gateway ID
+   * @throws {Promise<AWSError>}
+   */
+  public get apiGatewayId(): Promise<string | AWSError> {
+    if (this._apiGatewayId !== undefined) {
+      this._apiGatewayId
+    }
+
+    return (async () => {
+      const s3 = new AWS.S3()
+
+      return await s3.getObject({
+        Bucket: 'sfj-functions',
+        Key: this.storeAccount,
+      }).promise()
+        .then(obj => JSON.parse(obj.Body?.toString()).apiGateway)
+        .catch(async (error) => {
+          if (error.statusCode === 404) {
+            const apiGateway = await this.createApiGateway()
+
+            await s3.putObject({
+              Bucket: 'sfj-functions',
+              Key: this.storeAccount,
+              Body: JSON.stringify({ apiGateway }),
+            }).promise()
+
+            return apiGateway
+          }
+        })
+    })()
+  }
+
+  /**
+   * Hashes the function code
+   * @param {Buffer} file
+   */
   private functionHash(file: Buffer) {
     const shaObj = new jsSHA('SHA-224', 'BYTES');
     shaObj.update(file.toString())
     return shaObj.getHash('HEX')
   }
 
+  /** List functions deployed to this store */
   public async listFunctions() {
     const lambda = new AWS.Lambda()
     const functions = await lambda.listFunctions().promise()
@@ -45,6 +106,7 @@ class AWSProvider extends BaseProvider {
     return functionsObj
   }
 
+  /** Updates the function code */
   private async updateFunction(functionHash: string, content: Buffer) {
     const params = {
       FunctionName: `sfj-${functionHash}`,
@@ -57,7 +119,14 @@ class AWSProvider extends BaseProvider {
     await lambda.updateFunctionCode(params).promise()
   }
 
+  /**
+   * Create a new Lambda function and setup a route on API Gateway
+   * @param {string} functionName Name used on the API Gateway URL route
+   * @param {string} functionHash Code's hash, unique per Lambda function
+   * @param {Buffer} content Function code
+   */
   private async createFunction(functionName: string, functionHash: string, content: Buffer) {
+    this.createFunction
     const lambda = new AWS.Lambda()
 
     const params = {
@@ -112,6 +181,11 @@ class AWSProvider extends BaseProvider {
     return respApi.ApiEndpoint
   }
 
+  /**
+   * Creates or update a function, based on its contents hash
+   * @param {string} functionName Name used on the API Gateway URL route
+   * @param {Buffer} content Function code
+   */
   public async createOrUpdateFunction(functionName: string, content: Buffer) {
     const existingFunctions = await this.listFunctions()
 
@@ -131,6 +205,11 @@ class AWSProvider extends BaseProvider {
     }
   }
 
+  /**
+   * Creates or update multiple functions more efficiently
+   * @param {string} functionName Name used on the API Gateway URL route
+   * @param {Buffer} content Function code
+   */
   public async createOrUpdateFunctionList(functions: Record<string, Buffer>) {
     const existingFunctions = await this.listFunctions()
 

--- a/provider/AWSProvider.ts
+++ b/provider/AWSProvider.ts
@@ -126,7 +126,6 @@ class AWSProvider extends BaseProvider {
    * @param {Buffer} content Function code
    */
   private async createFunction(functionName: string, functionHash: string, content: Buffer) {
-    this.createFunction
     const lambda = new AWS.Lambda()
 
     const params = {

--- a/provider/AWSProvider.ts
+++ b/provider/AWSProvider.ts
@@ -59,7 +59,7 @@ class AWSProvider extends BaseProvider {
     return (async () => {
       const s3 = new AWS.S3()
 
-      return await s3.getObject({
+      return s3.getObject({
         Bucket: 'sfj-functions',
         Key: this.storeAccount,
       }).promise()


### PR DESCRIPTION
To improve observability, we want to use one API Gateway per store.

To do so, we now save the API Gateway id on S3 and retrieves it when needed. If it doesn't exist, the API Gateway will be created.