### PR TITLE
Setup route and integration on store's API Gateway

### DIFF
--- a/provider/AWSProvider.ts
+++ b/provider/AWSProvider.ts
@@ -1,11 +1,10 @@
 import { BaseProvider } from './BaseProvider'
-import AWS, { AWSError } from 'aws-sdk'
+import AWS from 'aws-sdk'
 import jsSHA from 'jssha'
 
 /** Implements the AWS provider for serverless functions */
 class AWSProvider extends BaseProvider {
   private _accountId: Promise<string>
-  private _apiGatewayId: Promise<string>
   private region: string
   private storeAccount: string
   private awsResource: string
@@ -18,16 +17,65 @@ class AWSProvider extends BaseProvider {
     super(storeAccount)
     this.storeAccount = storeAccount
     this.region = 'us-east-2'
-    // this.awsResource = 'service-role/any'
     this.awsResource = 'lambda-ex'
     AWS.config.update({ region: this.region })
+  }
+
+  /**
+   * Creates or update a function, based on its contents hash
+   * @param {string} functionName Name used on the API Gateway URL route
+   * @param {Buffer} content Function code
+   */
+  public async getOrCreateFunction(functionName: string, content: Buffer) {
+    const hash = this.functionHash(content)
+    console.log(`Function ${functionName} hash: ${hash}`)
+
+    const lambdaArn = await this.getOrCreateLambda(functionName, hash, content)
+    const integrationId = await this.getOrCreateIntegration(functionName, lambdaArn)
+
+    return `https://${integrationId}.execute-api.${this.region}.amazonaws.com/${functionName}`
+  }
+
+  /**
+   * Retrieves from S3 the API Gateway ID for the store, creating it if needed.
+   * @returns {Promise<string>} The API Gateway ID
+   */
+  public async getOrCreateApiGateway(): Promise<string> {
+    if (this._apiGatewayId !== undefined) {
+      return this._apiGatewayId
+    }
+
+    const s3 = new AWS.S3()
+
+    try {
+      const store = await s3.getObject({
+        Bucket: 'sfj-functions',
+        Key: this.storeAccount,
+      }).promise()
+
+      return JSON.parse(store.Body?.toString()).apiGateway
+    }
+    catch (error) {
+        if (error.statusCode !== 404) {
+          throw error
+        }
+        const apiGateway = await this.createApiGateway()
+
+        await s3.putObject({
+          Bucket: 'sfj-functions',
+          Key: this.storeAccount,
+          Body: JSON.stringify({ apiGateway }),
+        }).promise()
+
+        return apiGateway
+    }
   }
 
   /**
    * Retrieves the AWS Account ID based on caller's identity
    * @returns {Promise<string>} The account id
    */
-  get accountId(): Promise<string> {
+  private get accountId(): Promise<string> {
     if (this._accountId === undefined)
       this._accountId = ((new AWS.STS()).getCallerIdentity().promise()).then(x => x.Account)
 
@@ -43,41 +91,9 @@ class AWSProvider extends BaseProvider {
       ProtocolType: "HTTP",
     }).promise()
 
+    console.log(gateway.ApiId)
+
     return gateway.ApiId
-  }
-
-  /**
-   * Retrieves from S3 the API Gateway ID for the store, creating it if needed.
-   * @returns {Promise<string>} The API Gateway ID
-   * @throws {Promise<AWSError>}
-   */
-  public get apiGatewayId(): Promise<string | AWSError> {
-    if (this._apiGatewayId !== undefined) {
-      this._apiGatewayId
-    }
-
-    return (async () => {
-      const s3 = new AWS.S3()
-
-      return await s3.getObject({
-        Bucket: 'sfj-functions',
-        Key: this.storeAccount,
-      }).promise()
-        .then(obj => JSON.parse(obj.Body?.toString()).apiGateway)
-        .catch(async (error) => {
-          if (error.statusCode === 404) {
-            const apiGateway = await this.createApiGateway()
-
-            await s3.putObject({
-              Bucket: 'sfj-functions',
-              Key: this.storeAccount,
-              Body: JSON.stringify({ apiGateway }),
-            }).promise()
-
-            return apiGateway
-          }
-        })
-    })()
   }
 
   /**
@@ -90,51 +106,25 @@ class AWSProvider extends BaseProvider {
     return shaObj.getHash('HEX')
   }
 
-  /** List functions deployed to this store */
-  public async listFunctions() {
-    const lambda = new AWS.Lambda()
-    const functions = await lambda.listFunctions().promise()
-    const functionsObj: Record<string, { url: string }> = {}
-
-    functions?.Functions?.forEach((item) => {
-      if (item.FunctionName && item.Handler) {
-        if (item.FunctionName.startsWith('sfj-'))
-          functionsObj[item.FunctionName.substring(4)] = { ...item, url: item.Handler }
-      }
-    })
-
-    return functionsObj
-  }
-
-  /** Updates the function code */
-  private async updateFunction(functionHash: string, content: Buffer) {
-    const params = {
-      FunctionName: `sfj-${functionHash}`,
-      ZipFile: content,
-      Publish: true,
-    }
-
-    const lambda = new AWS.Lambda()
-
-    await lambda.updateFunctionCode(params).promise()
+  private getFunctionName(hash: string): string {
+    return `sfj-${hash}`
   }
 
   /**
    * Create a new Lambda function and setup a route on API Gateway
-   * @param {string} functionName Name used on the API Gateway URL route
+   * @param {string} name Name used on the API Gateway URL route
    * @param {string} functionHash Code's hash, unique per Lambda function
    * @param {Buffer} content Function code
    */
-  private async createFunction(functionName: string, functionHash: string, content: Buffer) {
-    this.createFunction
+  private async createFunction(name: string, hash: string, content: Buffer) {
     const lambda = new AWS.Lambda()
 
     const params = {
       Code: {
         ZipFile: content,
       },
-      Description: `StoreFramework Function - ${functionName}`,
-      FunctionName: `sfj-${functionHash}`,
+      Description: `StoreFramework Function - ${name}`,
+      FunctionName: this.getFunctionName(hash),
       Handler: 'index.handler',
       Publish: true,
       Role: `arn:aws:iam::${await this.accountId}:role/${this.awsResource}`,
@@ -151,83 +141,91 @@ class AWSProvider extends BaseProvider {
 
     console.log('creating function with role:', params.Role)
 
-    const functionResp = await lambda.createFunction(params).promise()
+    return lambda.createFunction(params).promise()
+  }
 
-    const apigateway = new AWS.ApiGatewayV2()
+  private async getOrCreateLambda(name: string, hash: string, content: Buffer) {
+    console.log(`Trying to create function ${name}...`)
+    let functionArn: string
 
-    const respApi = await apigateway
-      .createApi({
-        Name: `${this.storeAccount}-api-gateway-v2-${functionName}`,
-        ProtocolType: 'HTTP',
-        Target: functionResp.FunctionArn,
-        RouteKey: '$default',
-      })
-      .promise()
+    try {
+      const functionResp = await this.createFunction(name, hash, content)
+      console.log(`Function ${name} created`)
+      functionArn = functionResp.FunctionArn
+    }
+    catch (error) {
+      if (error.code !== 'ResourceConflictException') {
+        throw error;
+      }
+      console.log(`Function ${name} already existed`)
 
-    console.log('creating API Gateway V2: ', `${this.storeAccount}-api-gateway-v2-${functionName}`)
-    console.log('function ARN', functionResp.FunctionArn)
-    console.log('functions endpoint', respApi.ApiEndpoint)
+      const lambda = new AWS.Lambda()
+      const functionResp = await lambda.getFunction({
+        FunctionName: this.getFunctionName(hash),
+      }).promise()
 
-    await lambda
+      functionArn = functionResp.Configuration.FunctionArn
+    }
+
+    return functionArn
+  }
+
+  private async getOrCreateIntegration(functionName: string, lambdaArn: string) {
+    const gatewayId = await this.getOrCreateApiGateway()
+
+    const apiGateway = new AWS.ApiGatewayV2()
+    const integrations = await apiGateway.getIntegrations({
+      ApiId: gatewayId,
+    }).promise()
+
+    const oldIntegration = integrations.Items.filter(integration => integration.IntegrationUri === lambdaArn)
+
+    if (oldIntegration.length > 0) {
+      console.log('Integration for API exists', oldIntegration[0].IntegrationId)
+      return oldIntegration[0].IntegrationId
+    }
+
+    console.log('Adding Integration for API')
+    const newIntegration = await apiGateway.createIntegration({
+      ApiId: gatewayId,
+      IntegrationType: 'AWS_PROXY',
+      IntegrationUri: lambdaArn,
+      PayloadFormatVersion: '2.0',
+    }).promise()
+    console.log(newIntegration)
+
+    await this.addRouteToApi(functionName, newIntegration.IntegrationId)
+
+    await this.addLambdaPermissions(lambdaArn, newIntegration.IntegrationId)
+
+    return newIntegration.IntegrationId
+  }
+
+  private async addRouteToApi(name: string, integrationId: string) {
+    const gatewayId = await this.getOrCreateApiGateway()
+
+    const apiGateway = new AWS.ApiGatewayV2()
+
+    console.log('Adding route to API')
+    const route = await apiGateway.createRoute({
+      ApiId: gatewayId,
+      RouteKey: `ANY /${name}`,
+      Target: `integrations/${integrationId}`,
+    }).promise()
+    console.log(route)
+  }
+
+  private async addLambdaPermissions(lambdaArn: string, gatewayId: string) {
+    const lambda = new AWS.Lambda()
+    return lambda
       .addPermission({
-        FunctionName: params.FunctionName,
-        StatementId: 'random-string',
+        FunctionName: lambdaArn,
+        StatementId: `${lambdaArn}`,
         Action: 'lambda:InvokeFunction',
         Principal: 'apigateway.amazonaws.com',
-        SourceArn: `arn:aws:execute-api:${this.region}:${await this.accountId}:${respApi.ApiId}/*/$default`,
+        SourceArn: `arn:aws:execute-api:${this.region}:${await this.accountId}:${gatewayId}/*/*/*`,
       })
       .promise()
-
-    return respApi.ApiEndpoint
-  }
-
-  /**
-   * Creates or update a function, based on its contents hash
-   * @param {string} functionName Name used on the API Gateway URL route
-   * @param {Buffer} content Function code
-   */
-  public async createOrUpdateFunction(functionName: string, content: Buffer) {
-    const existingFunctions = await this.listFunctions()
-
-    const hash = this.functionHash(content)
-
-    if (hash in existingFunctions) {
-      console.log(`Updating function ${functionName}`)
-      console.log('Function hash', hash)
-      await this.updateFunction(hash, content)
-      console.log(`Function ${functionName} updated`)
-    } else {
-      console.log(`Creating function ${functionName}... `)
-      const url = await this.createFunction(functionName, hash, content)
-      console.log('Function hash', hash)
-      console.log(`Function ${functionName} created`)
-      return url
-    }
-  }
-
-  /**
-   * Creates or update multiple functions more efficiently
-   * @param {string} functionName Name used on the API Gateway URL route
-   * @param {Buffer} content Function code
-   */
-  public async createOrUpdateFunctionList(functions: Record<string, Buffer>) {
-    const existingFunctions = await this.listFunctions()
-
-    const urls: Record<string, string> = {}
-
-    await Promise.all(
-      Object.entries(functions).map(async ([functionName, content]) => {
-        const functionHash = this.functionHash(content)
-
-        if (functionName in existingFunctions) {
-          this.updateFunction(functionHash, content)
-        }
-
-        urls[functionName] = await this.createFunction(functionName, functionHash, content)
-      })
-    )
-
-    return urls
   }
 }
 


### PR DESCRIPTION
To improve observability, we want to use one API Gateway per store.

This PR add methods to setup an integration on API Gateway and now it uses them on the public method `getOrCreateFunction`.