### PR TITLE
Compress function in provider, not in Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@types/yazl": "^2.4.2",
     "aws-sdk": "^2.853.0",
     "glob": "^7.1.6",
     "jssha": "^3.2.0",
     "ts-loader": "^8.0.17",
     "typescript": "^4.2.2",
     "webpack": "^5.24.2",
+    "yazl": "^2.5.1",
     "zip-webpack-plugin": "^4.0.1"
   },
   "scripts": {

--- a/provider/AWSProvider/index.ts
+++ b/provider/AWSProvider/index.ts
@@ -25,7 +25,7 @@ class AWSProvider extends BaseProvider {
    * Creates or update a function, based on its contents hash
    * @param {string} functionName Name used on the API Gateway URL route
    * @param {Buffer} content Function code
-   * @returns {string} The final URL used to invoke the function
+   * @returns The final URL used to invoke the function
    */
   public async getOrCreateFunction(functionName: string, content: Buffer) {
     const hash = hashFunction(content)
@@ -33,7 +33,7 @@ class AWSProvider extends BaseProvider {
 
     const lambdaArn = await getOrCreateLambda({
       accountId: await this.accountId,
-      content,
+      content: await this.zipFunction(content),
       functionName,
       hash,
     })
@@ -46,7 +46,7 @@ class AWSProvider extends BaseProvider {
       storeAccount: this.storeAccount,
     })
 
-    return getFunctionURL(integrationId, AWS_REGION, functionName)
+    return getFunctionURL(integrationId, AWS_REGION, hash)
   }
 
   /**

--- a/provider/AWSProvider/lambda.ts
+++ b/provider/AWSProvider/lambda.ts
@@ -78,7 +78,7 @@ export const addLambdaPermissions = async (hash: string, accountId: string, gate
   return lambda
     .addPermission({
       FunctionName: getLambdaName(hash),
-      StatementId: hash,
+      StatementId: `${gatewayId}-${hash}`,
       Action: 'lambda:InvokeFunction',
       Principal: 'apigateway.amazonaws.com',
       SourceArn: getLambdaPermissionSourceArn(accountId, gatewayId),

--- a/provider/BaseProvider.ts
+++ b/provider/BaseProvider.ts
@@ -1,3 +1,5 @@
+import yazl from 'yazl'
+
 export type Functions = Record<string, { url: string }>
 
 export abstract class BaseProvider {
@@ -8,4 +10,18 @@ export abstract class BaseProvider {
   }
 
   public abstract getOrCreateFunction(functionName: string, content: Buffer): Promise<string | undefined>
+
+  public async zipFunction(content: Buffer): Promise<Buffer> {
+    const zipfile = new yazl.ZipFile()
+    zipfile.addBuffer(content, 'index.js')
+
+    return new Promise((resolve, reject) => {
+      const data = []
+
+      zipfile.outputStream.on('data', (chunk) => data.push(chunk))
+      zipfile.outputStream.on('end', () => resolve(Buffer.concat(data)))
+      zipfile.outputStream.on('error', (error) => reject(error))
+      zipfile.end()
+    })
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,7 @@ function mainConfig(root, distDir) {
       libraryTarget: 'umd',
     },
     target: 'node',
-    mode: 'development',
+    mode: 'production',
     optimization: {
       usedExports: false,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yazl@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/yazl/-/yazl-2.4.2.tgz#d5f8a4752261badbf1a36e8b49e042dc18ec84bc"
+  integrity sha512-T+9JH8O2guEjXNxqmybzQ92mJUh2oCwDDMSSimZSe1P+pceZiFROZLYmcbqkzV5EUwz6VwcKXCO2S2yUpra6XQ==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@^4.18.0":
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.18.0.tgz#50fbce93211b5b690895d20ebec6fe8db48af1f6"


### PR DESCRIPTION
We were hashing the zip file, which contains metadata such as created time. It would make us store two functions that perform identically just because they were created in different time.

This PR allows the Webpack to pass only the function contents and the provider takes care of hashing its minified code and creating a zip file for upload.