### PR TITLE
Create stage with autodeploy on API Gateway

### DIFF
--- a/provider/AWSProvider/apiGateway.ts
+++ b/provider/AWSProvider/apiGateway.ts
@@ -40,6 +40,8 @@ export const setupApiGateway = async (params: ApiGatewaySetupParams) => {
 
   await addRouteToApi(params.hash, gatewayId, newIntegration.IntegrationId)
 
+  await createStage(gatewayId)
+
   console.log('adding permissions');
   addLambdaPermissions(params.hash, params.accountId, gatewayId)
 
@@ -114,5 +116,15 @@ const createIntegration = (gatewayId: string, lambdaArn: string) => {
     IntegrationType: 'AWS_PROXY',
     IntegrationUri: lambdaArn,
     PayloadFormatVersion: '2.0',
+  }).promise()
+}
+
+const createStage = (gatewayId: string) => {
+  const apiGateway = new AWS.ApiGatewayV2()
+
+  return apiGateway.createStage({
+    ApiId: gatewayId,
+    StageName: '$default',
+    AutoDeploy: true,
   }).promise()
 }

--- a/provider/AWSProvider/index.ts
+++ b/provider/AWSProvider/index.ts
@@ -38,7 +38,7 @@ class AWSProvider extends BaseProvider {
       hash,
     })
 
-    const { integrationId } = await setupApiGateway({
+    const { gatewayId } = await setupApiGateway({
       accountId: await this.accountId,
       functionName,
       hash,
@@ -46,7 +46,7 @@ class AWSProvider extends BaseProvider {
       storeAccount: this.storeAccount,
     })
 
-    return getFunctionURL(integrationId, AWS_REGION, hash)
+    return getFunctionURL(gatewayId, AWS_REGION, hash)
   }
 
   /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,6 @@ async function deployFunctions(functions, provider) {
     const functionName = path.parse(path.join(functionPath, '..')).name
 
     urls[functionName] = await provider.getOrCreateFunction(functionName, content)
-    console.log('aqui');
   }))
 
   return urls


### PR DESCRIPTION
To be accessed by an URL, functions should have a stage and a deployment. We're creating a stage here with auto deploy enabled, so we don't need to manually create a deployment.